### PR TITLE
Go 1.7 -> 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SHELL := /bin/bash
 PKG := github.com/Clever/mesos-visualizer
 PKGS := $(shell go list ./... | grep -v /vendor/)
 EXECUTABLE := $(shell basename $(PKG))
-$(eval $(call golang-version-check,1.7))
+$(eval $(call golang-version-check,1.8))
 
 $(GOPATH)/bin/glide:
 	@go get github.com/Masterminds/glide

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   post:
   - cd $HOME && git clone --depth 1 -v git@github.com:clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-  - $HOME/ci-scripts/circleci/golang-install 1.7
+  - $HOME/ci-scripts/circleci/golang-install 1.8
   services:
   - docker
 checkout:

--- a/mesos/state.go
+++ b/mesos/state.go
@@ -50,7 +50,7 @@ type Resources struct {
 type Framework struct {
 	Active           bool        `json:"active"`
 	Checkpoint       bool        `json:"checkpoint"`
-	CompletedTasks   []Task      `json:"checkpoint"`
+	CompletedTasks   []Task      `json:"completed_tasks"`
 	FailoverTimeout  int64       `json:"failover_timeout"`
 	Hostname         string      `json:"hostname"`
 	ID               string      `json:"id"`


### PR DESCRIPTION
Uses Go 1.8 in Circle build and golang-version-check.
You were assigned as the most active recent contributor to this repo. If LGTY, please merge away! Else, please reassign and share the joy of Go 1.8, or ask in #golang if you have any questions.